### PR TITLE
Fix: mu-browser contents should be 100% width

### DIFF
--- a/src/stylesheets/_browser.scss
+++ b/src/stylesheets/_browser.scss
@@ -2,6 +2,7 @@
   iframe {
     margin: 0;
     width: 100%;
+    border: none;
   }
   border-top: 2em solid rgba(230, 230, 230, 0.7);
   box-shadow: 0 0.1em 1em 0 rgba(0, 0, 0, 0.4);

--- a/src/stylesheets/_browser.scss
+++ b/src/stylesheets/_browser.scss
@@ -1,6 +1,7 @@
 .mu-browser {
   iframe {
     margin: 0;
+    width: 100%;
   }
   border-top: 2em solid rgba(230, 230, 230, 0.7);
   box-shadow: 0 0.1em 1em 0 rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/677436/27192941-84cad536-51d3-11e7-93ff-efc7bb1aa29b.png)

After: 

![image](https://user-images.githubusercontent.com/677436/27192921-71d73938-51d3-11e7-9161-0e3b312d7212.png)
