### PR TITLE
Fix navbar overflow

### DIFF
--- a/src/stylesheets/_navbar.scss
+++ b/src/stylesheets/_navbar.scss
@@ -71,6 +71,8 @@ $avatar-size: 40px;
   .mu-navbar-avatar {
     @include display-flex;
 
+    flex-shrink: 0;
+
     .notifications-box {
       .fa {
         color: $mu-color-primary;

--- a/src/stylesheets/_navbar.scss
+++ b/src/stylesheets/_navbar.scss
@@ -32,6 +32,8 @@ $avatar-size: 40px;
 
       @include display-flex(row, flex-start, center);
 
+      overflow: hidden;
+
       .mu-breadcrumb-list-item {
         &:before {
           content: '/';
@@ -58,6 +60,9 @@ $avatar-size: 40px;
         &.last {
           @extend .mu-disabled;
           a { color: $mu-color-disabled }
+
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
       }
     }


### PR DESCRIPTION
## :dart: Goal

Fix overflown breadcrumb when it's too long, and fix an issue with the avatar caret on navbar.

## :camera_flash: Screenshots

### How it looked like 

Overflown text, broken layout

![image](https://user-images.githubusercontent.com/11304439/99537109-01f52200-298a-11eb-8539-7fe39dcb6e88.png)

______

### How it looks now

Ellipsis on breadcrumb, fixed layout

![image](https://user-images.githubusercontent.com/11304439/99536725-7d0a0880-2989-11eb-8ac2-676db01d796e.png)


## :spiral_notepad: Note to reviewers

I added the ellipsis to the last element on the breadcrumb only. This will fix most issues with long exercise names, but on rare cases with extremely long organization, chapter and lesson names, or a small screen not small enough to be hamburger-worthy, it may still look wrong.

Unfortunately, it's not so simple to add ellipsis to multiple elements (remember the breadcrumb is composed of multiple `<li>`s) without it looking like this:

![image](https://user-images.githubusercontent.com/11304439/99537866-f9e9b200-298a-11eb-9068-2ff16c263fff.png)