### PR TITLE
Add inverted style navbar

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+yarn && yarn build
+cd gem && ./bin/setup && bundle exec rake

--- a/src/stylesheets/_navbar.scss
+++ b/src/stylesheets/_navbar.scss
@@ -130,6 +130,20 @@ $avatar-size: 40px;
     user-select: none;
     pointer-events: none;
   }
+
+  &.mu-inverted {
+    img {
+      box-shadow: 0 0 0 2px white;
+    }
+
+    .caret, .navbar-icon {
+      color: white;
+    }
+
+    .mu-level-number {
+      color: $mu-color-primary;
+    }
+  }
 }
 
 .da-mumuki {

--- a/src/stylesheets/_navbar.scss
+++ b/src/stylesheets/_navbar.scss
@@ -74,10 +74,6 @@ $avatar-size: 40px;
     flex-shrink: 0;
 
     .notifications-box {
-      .fa {
-        color: $mu-color-primary;
-      }
-
       .badge-notifications {
         position: absolute;
         right: 4px;
@@ -116,6 +112,7 @@ $avatar-size: 40px;
   }
 
   .navbar-icon {
+    color: $mu-color-primary;
     margin-left: 20px;
     vertical-align: middle;
   }


### PR DESCRIPTION
## :dart: Goal 

Add high-contrast version of icons + avatar for dark navbars.

I'm also adding a `build.sh` script because I'm done with doing it manually

## :spiral_notepad: Instructions for organizations that need inverted navbar

Add on the organization's extension javascript:
```javascript
mumuki.load(function() {
  $("nav").addClass("mu-inverted");
}
```

## :camera_flash: Screenshots

### Inverted navbar
![image](https://user-images.githubusercontent.com/11304439/101069778-361b3600-3579-11eb-898c-66946f6c7dc7.png)
_______
### Normal navbar
![image](https://user-images.githubusercontent.com/11304439/101069853-4df2ba00-3579-11eb-8c9c-bd63540a7962.png)
_______
### Some organizations could choose between both styles
![image](https://user-images.githubusercontent.com/11304439/101070181-c2c5f400-3579-11eb-8849-771ba4f10b1a.png)
![image](https://user-images.githubusercontent.com/11304439/101070133-af1a8d80-3579-11eb-9450-d2f14d467aab.png)

