### PR TITLE
Use FontAwesome5 styles

### DIFF
--- a/src/javascripts/_er-diagram.js
+++ b/src/javascripts/_er-diagram.js
@@ -102,7 +102,7 @@ mumuki.load(function () {
   }
 
   function keyIconFor(column, field) {
-    return !!column[field] ? '<i class="fa fa-fw fa-key mu-erd-' + field + '"></i>' : '';
+    return !!column[field] ? '<i class="fas fa-fw fa-key mu-erd-' + field + '"></i>' : '';
   }
 
   function generateEntityColumns(entity, index) {

--- a/src/javascripts/_file-browser.js
+++ b/src/javascripts/_file-browser.js
@@ -91,7 +91,7 @@ mumuki.load(function () {
   function getExplorerHeader(canBrowse) {
     return $([
       '<header>',
-          canBrowse ? '<i class="fa fa-fw fa-arrow-left"></i>' : '',
+          canBrowse ? '<i class="fas fa-fw fa-arrow-left"></i>' : '',
       '  <input class="mu-file-browser-path" type="text" readonly>',
       '</header>'
     ].join(''))

--- a/src/javascripts/_pre-copy-paste.js
+++ b/src/javascripts/_pre-copy-paste.js
@@ -80,7 +80,7 @@ mumuki.load(function () {
         $pre.children('span').remove();
         var $clipboard = $('<span>', {
           class: 'mu-clipboard',
-          html: '<i class="fa fa-fw fa-clipboard"></i> <span>' + getCopiedText().copy + '</span>',
+          html: '<i class="far fa-fw fa-copy"></i> <span>' + getCopiedText().copy + '</span>',
           click: function () {
             copyToClipboard($code.text());
             pasteInEditor($code.text());

--- a/src/javascripts/_sql-table.js
+++ b/src/javascripts/_sql-table.js
@@ -45,7 +45,7 @@ mumuki.load(function () {
   }
 
   function keyIconFor(column, field) {
-    return !!column[field] ? '<i class="fa fa-fw fa-key mu-sql-table-' + field + '"></i>' : '';
+    return !!column[field] ? '<i class="fas fa-fw fa-key mu-sql-table-' + field + '"></i>' : '';
   }
 
   $.fn.renderSqlTable = function () {
@@ -73,7 +73,7 @@ mumuki.load(function () {
       var text = $th.text();
       $th.empty();
       if ($th.children('i').length == 0) {
-        $th.prepend('<i class="fa fa-fw fa-key ' + $th.attr('class') + '"></i>');
+        $th.prepend('<i class="fas fa-fw fa-key ' + $th.attr('class') + '"></i>');
       }
       $th.append('<span>' + text + '</span>');
     });

--- a/src/javascripts/_web-browser.js
+++ b/src/javascripts/_web-browser.js
@@ -12,7 +12,7 @@ mumuki.load(function () {
       '      <span>', title, '<span>',
       '    </li>',
       '    <li class="mu-browser-tab mu-browser-new-tab">',
-      '      <i class="fa fa-fw fa-plus"></i>',
+      '      <i class="fas fa-fw fa-plus"></i>',
       '    </li>',
       '  </ul>',
       '  <div class="mu-browser-bar">',

--- a/src/stylesheets/_fa5.scss
+++ b/src/stylesheets/_fa5.scss
@@ -1,0 +1,7 @@
+.fa5-text {
+  padding-left: 5px;
+}
+
+.fa5-text-r {
+  padding-right: 5px;
+}

--- a/src/stylesheets/_vendor.scss
+++ b/src/stylesheets/_vendor.scss
@@ -8,4 +8,3 @@
 @import "../../node_modules/@fortawesome/fontawesome-free/scss/brands.scss";
 @import "../../node_modules/@fortawesome/fontawesome-free/scss/regular.scss";
 @import "../../node_modules/@fortawesome/fontawesome-free/scss/solid.scss";
-@import "../../node_modules/@fortawesome/fontawesome-free/scss/v4-shims.scss";

--- a/src/stylesheets/components/_browser.scss
+++ b/src/stylesheets/components/_browser.scss
@@ -64,7 +64,7 @@ $mu-color-browser-inactive-tabs: darken($mu-color-component-title-background, 5%
         cursor: pointer;
         font-size: 25px;
         margin-right: 10px;
-        @extend .fa;
+        @extend .fas;
         @extend .fa-fw;
         &.mu-arrow-left {
           @extend .fa-arrow-circle-left;
@@ -73,7 +73,7 @@ $mu-color-browser-inactive-tabs: darken($mu-color-component-title-background, 5%
           @extend .fa-arrow-circle-right;
         };
         &.mu-refresh {
-          @extend .fa-refresh;
+          @extend .fa-sync-alt;
         }
       }
       input {

--- a/src/stylesheets/components/_mu-erd.scss
+++ b/src/stylesheets/components/_mu-erd.scss
@@ -14,7 +14,7 @@ $mu-erd-margin: 20px;
     width: calc(100% - #{$mu-erd-margin});
     height: 100%;
     position: absolute;
-    margin-left: $mu-erd-margin / 2;
+    margin-left: $mu-erd-margin;
   }
 }
 

--- a/src/stylesheets/components/_mu-file-browser.scss
+++ b/src/stylesheets/components/_mu-file-browser.scss
@@ -13,7 +13,7 @@
       cursor: pointer;
       font-size: 25px;
       margin-right: 10px;
-      @extend .fa ;
+      @extend .fas;
       @extend .fa-fw;
       @extend .fa-arrow-circle-left;
     }
@@ -62,10 +62,15 @@
           height: 70px;
           font-size: 64px;
           margin: auto;
-          @extend .fa ;
           @extend .fa-fw;
-          &.file { @extend .fa-file-o; }
-          &.folder { @extend .fa-folder; }
+          &.file {
+            @extend .far;
+            @extend .fa-file;
+          }
+          &.folder {
+            @extend .fas;
+            @extend .fa-folder;
+          }
         }
         span {
           width: 100%;

--- a/src/stylesheets/mumuki-styles.scss
+++ b/src/stylesheets/mumuki-styles.scss
@@ -9,4 +9,5 @@
 @import 'navbar';
 @import 'styles';
 @import 'navs';
+@import 'fa5';
 @import 'components/components';

--- a/tag.sh
+++ b/tag.sh
@@ -29,4 +29,4 @@ git tag "v${NEW_VERSION}"
 echo "[Mumuki::Styles] Pushing..."
 git push origin HEAD --tags
 
-echo "[Mumuki::Styles] Pushed. Travis will do the rest"
+echo "[Mumuki::Styles] Pushed. GitHub Actions will do the rest"


### PR DESCRIPTION
## :dart: Goal

Use FontAwesome5 syntax and remove FontAwesome4 compatibility.

## :warning: Backwards compatibility

As this PR will break the icons on projects that don't update their syntax, we should make sure our apps are updated before merging (or make this a major). Laboratory does it here: https://github.com/mumuki/mumuki-laboratory/pull/1533

All icons are updated to match their old visual style. For example, FA4 `fa-refresh` was moved to `fa-sync-alt` in FA5, while FA5 `fa-refresh` is different.

The only exception to this is `fa-clipboard`, which I changed to `fa-copy` to use a more standard copy icon.

![fa-copy](https://user-images.githubusercontent.com/11304439/103539515-fea0f180-4e76-11eb-9798-e9e3ac7dea00.png)
